### PR TITLE
lodash should be a dependency, not a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "dependencies": {
     "chalk": "^1.0.0",
+    "lodash": "^4.11.1",
     "yeoman-generator": "^0.22.0",
     "yosay": "^1.0.2"
   },
@@ -27,7 +28,6 @@
     "gulp-mocha": "^2.0.0",
     "gulp-nsp": "^2.1.0",
     "gulp-plumber": "^1.0.0",
-    "lodash": "^4.11.1",
     "slugg": "^1.0.0",
     "yeoman-assert": "^2.0.0",
     "yeoman-test": "^1.0.0"


### PR DESCRIPTION
Currently when installing the generator, lodash is not found as a dependency. @alex-bezek helped figure this out. 

```
TypeError: _.upperFirst is not a function
    at toClassName (/Users/mbutler/.nvm/versions/node/v6.3.0/lib/node_modules/generator-terra-module/generators/app/index.js:21:12)
```

Until this is merged, using `npm link` in the cloned repository will work. 
