### PR TITLE
Add dir attribute to html tag

### DIFF
--- a/generators/app/templates/.storybook/head.html
+++ b/generators/app/templates/.storybook/head.html
@@ -2,4 +2,5 @@
 <script>
   var root = document.getElementsByTagName( 'html' )[0];
   root.setAttribute( 'class', 'terra-Application' );
+  root.setAttribute( 'dir', 'ltr' );
 </script>


### PR DESCRIPTION
If the dir attribute is not set to ltr or rtl, terra-mixins will not work. 