### PR TITLE
Added team at in the pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ If you have anything else that you think may be relevant to this issue, list it 
 Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].
 
 Thanks for contributing to Terra. 
+@cerner/terra
 
 [CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
 [License]: ../blob/master/LICENSE


### PR DESCRIPTION
### Summary
Add `@cerner/terra` in the pull request template. By this @ label, we can view all PR across all repos under terra team.

### Additional Details

It looks like following screenshot(shows all open PR across all terra team's repos):
<img width="1143" alt="screen shot 2017-01-26 at 10 04 17 am" src="https://cloud.githubusercontent.com/assets/3724179/22339243/f026a154-e3ae-11e6-9f70-ae8ae7037271.png">

[Github search syntax](https://help.github.com/articles/searching-issues/#search-by-a-team-thats-mentioned-within-an-issue-or-pull-request)

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra 

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
