### PR TITLE
update travis ci to only build on pushes to master (all PRs and PR up…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ cache:
   yarn: true
   directories:
     - node_modules
+branches:
+  only:
+    - master

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,8 +2,10 @@ Cerner Corporation
 
 - Matt Butler [@Matt-Butler]
 - Rory Hardy [@gneatgeek]
+- Matt Henkes [@mjhenkes]
 - Ryan Manuel [@ryanthemanuel]
 
 [@gneatgeek]: https://github.com/gneatgeek
 [@Matt-Butler]: https://github.com/Matt-Butler
+[@mjhenkes]: http://github.com/mjhenkes
 [@ryanthemanuel]: https://github.com/ryanthemanuel

--- a/generators/app/templates/_.travis.yml
+++ b/generators/app/templates/_.travis.yml
@@ -5,3 +5,6 @@ cache:
   yarn: true
   directories:
     - node_modules
+branches:
+  only:
+    - master


### PR DESCRIPTION
…dates are still built). This is to avoid duplicate builds on

### Summary
To remove duplicate travis-ci builds on pull requests I added a whitelist to restrict push builds to master only. PR builds and pr update builds are unaffected.

### Additional Details
This should help reduce hubot pull request spam.

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
