### PR TITLE
add rest operator plugin. Update example to have prop types up top an…

### DIFF
--- a/generators/app/templates/_.babelrc
+++ b/generators/app/templates/_.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-object-assign"]
+  "plugins": ["transform-object-assign", "transform-object-rest-spread"]
 }

--- a/generators/app/templates/_.babelrc
+++ b/generators/app/templates/_.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-object-assign", "transform-object-rest-spread"]
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -38,6 +38,7 @@
     "babel-cli": "^6.18.0",
     "babel-jest": "^18.0.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "css-loader": "^0.26.1",

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -37,7 +37,6 @@
     "autoprefixer": "^6.6.1",
     "babel-cli": "^6.18.0",
     "babel-jest": "^18.0.0",
-    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",

--- a/generators/app/templates/src/projectName.jsx
+++ b/generators/app/templates/src/projectName.jsx
@@ -2,6 +2,16 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import '../src/<%= scssFileName %>.scss';
 
+const propTypes = {
+  name: PropTypes.string.isRequired,
+  variant: PropTypes.string.isRequired,
+};
+
+const defaultProps = {
+  name: 'default',
+  variant: '<%= projectCssClassName %>--default',
+};
+
 class <%= projectClassName %> extends React.Component {
   constructor() {
     super();
@@ -16,33 +26,29 @@ class <%= projectClassName %> extends React.Component {
   }
 
   render() {
+    const { name, variant, ...customProps } = this.props;
     const classes = classNames(['<%= projectCssClassName %>',
-      this.props.variant,
+      variant,
       this.state.isSelected && 'u-selected',
+      customProps.className,
     ]);
 
 
-    if (!this.props.name) {
+    if (!name) {
       return null;
     }
-    if (!this.props.variant) {
+    if (!variant) {
       return null;
     }
     return (<button
+      {...customProps}
       className={classes}
       onClick={this.handleClick}
-    >Terra, {this.props.name}</button>);
+    >Terra, {name}</button>);
   }
 }
 
-<%= projectClassName %>.propTypes = {
-  name: PropTypes.string.isRequired,
-  variant: PropTypes.string.isRequired,
-};
-
-<%= projectClassName %>.defaultProps = {
-  name: 'default',
-  variant: '<%= projectCssClassName %>--default',
-};
+<%= projectClassName %>.propTypes = propTypes;
+<%= projectClassName %>.defaultProps = defaultProps;
 
 export default <%= projectClassName %>;


### PR DESCRIPTION
…d use the rest operator for custom props.

### Summary
Updated the example to use the rest operator and have props up top as we have started doing.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
