### PR TITLE
Markdown and propstable are their own components

### DIFF
--- a/generators/app/templates/examples/Index.jsx
+++ b/generators/app/templates/examples/Index.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
-import PropsTable from '../../../packages/terra-site/src/PropsTable';
-import Markdown from '../../../packages/terra-site/src/Markdown';
+import PropsTable from 'terra-props-table';
+import Markdown from 'terra-markdown';
 import ReadMe from '../docs/README.md';
 // Component Source
 // eslint-disable-next-line import/no-webpack-loader-syntax, import/first, import/no-unresolved, import/extensions

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -33,7 +33,7 @@
     "react": "^15.4.2",
     "terra-mixins": "^1.0.0",
     "terra-props-table": "0.1.0",
-    "terra-markdown": "0.1.0",
+    "terra-markdown": "0.1.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -31,7 +31,9 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "react": "^15.4.2",
-    "terra-mixins": "^1.0.0"
+    "terra-mixins": "^1.0.0",
+    "terra-props-table": "0.1.0",
+    "terra-markdown": "0.1.0",
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",


### PR DESCRIPTION
### Summary
Updating with markdown and propsTable now being their own components in the monorepo.

@cerner/terra


