### PR TITLE
Update nightwatch script location

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -48,9 +48,9 @@
     "test": "npm run test:spec && npm run test:nightwatch-default",
     "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
     "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",
-    "test:nightwatch-default": "node ../../scripts/nightwatch/nightwatch.js",
-    "test:nightwatch-chrome": "node ../../scripts/nightwatch/nightwatch.js chrome",
-    "test:nightwatch-firefox": "node ../../scripts/nightwatch/nightwatch.js firefox",
-    "test:nightwatch-safari": "node ../../scripts/nightwatch/nightwatch-non-parallel.js safari"
+    "test:nightwatch-default": "node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js",
+    "test:nightwatch-chrome": "node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js chrome",
+    "test:nightwatch-firefox": "node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js firefox",
+    "test:nightwatch-safari": "node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari"
   }
 }


### PR DESCRIPTION
### Summary
Update the script config to pass default nightwatch tests.

To guarantee `npm run lint` & `npm run test` successfully:
1. Update the `terra-props-table` and `terra-markdown` in the `examples/index.jsx`. As `terra-props-table` and `terra-markdown` are still unreleases. They cannot be installed by `npm i`.
2. Comment things based on the lint error.
3. Run `npm run compile` to build `lib/` to make sure nightwatch pass.