### PR TITLE
Display component version

### DIFF
--- a/generators/app/templates/Index.jsx
+++ b/generators/app/templates/Index.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropsTable from 'terra-props-table';
 import Markdown from 'terra-markdown';
 import ReadMe from '<%= projectName %>/docs/README.md';
+import { version } from '<%= projectName %>/package.json';
 
 // Component Source
 // eslint-disable-next-line import/no-webpack-loader-syntax, import/first, import/no-unresolved, import/extensions
@@ -12,6 +13,7 @@ import <%= projectClassName %>Src from '!raw-loader!<%= projectName %>/src/<%= p
 
 const <%= projectClassName %>Examples = () => (
   <div>
+    <div id="version">Version: {version}</div>
     <Markdown id="readme" src={ReadMe} />
     <PropsTable id="props" src={<%= projectClassName %>Src} />
   </div>

--- a/test/app.js
+++ b/test/app.js
@@ -53,6 +53,7 @@ describe('generator-terra-module:app', function () {
     assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `import React from 'react';`);
     assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `import CakeSrc from '!raw-loader!waffle-cake/src/Cake';`);
     assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `import ReadMe from 'waffle-cake/docs/README.md';`);
+    assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `import { version } from 'waffle-cake/package.json';`);
     assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `export default CakeExamples;`);
   });
 });


### PR DESCRIPTION
### Summary
This update will display the component version on the functional testing site.

@cerner/terra


Relates to: https://github.com/cerner/terra-core/pull/170