### PR TITLE
Clinical package generation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,8 +4,10 @@ Cerner Corporation
 - Rory Hardy [@gneatgeek]
 - Matt Henkes [@mjhenkes]
 - Ryan Manuel [@ryanthemanuel]
+- Emily Rohrbough [@emilyrohrbough]
 
 [@gneatgeek]: https://github.com/gneatgeek
 [@Matt-Butler]: https://github.com/Matt-Butler
 [@mjhenkes]: http://github.com/mjhenkes
 [@ryanthemanuel]: https://github.com/ryanthemanuel
+[@emilyrohrbough]: https://github.com/emilyrohrbough

--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@ Then generate your new project:
 ```bash
 yo terra-module
 ```
+From here, you will be prompted with two messages:
+1. `Terra repository:`
+Input `terra-core` or `terra-clinical`. It defaults to `terra-core` if no input is provided.
+2. `Your module name:`
+Input the desired name of the react component being created. **Note**: the first prompt handles the name space prefixes.
 
-This will generate a project in the packages directory of a mono repo.  Make sure to type something other than the default when prompted for the project name.  After generating the project inside of the mono repo, you will need to add a link to your project's examples in site/App.jsx, routes for your project in site/Index.jsx, and links to your tests in site/TestLinks.jsx.  For nightwatch tests to run optimally, you will also need to update the mono repo's nightwatch.conf.js file to point to the nightwatch directory in the new package.
+Your new project will be generated in the packages directory of the chosen repository. After generating the project, add a link to your project's examples in site/App.jsx, routes for your project in site/Index.jsx, and links to your tests in site/TestLinks.jsx.
+
+Now you are ready to start building your terra module!
 
 # Contributing
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -42,7 +42,7 @@ function toCssClassName(str1, str2) {
  * Returns the repository prefix
  * @param {String} the repository name
  */
-function repoPrefix(repo) {
+function repositoryPrefix(repo) {
   return (repo === 'terra-core') ? 'terra' : repo;
 }
 
@@ -85,7 +85,7 @@ module.exports = yeoman.Base.extend({
     this.prompt(prompts, function (props) {
       this.props = props;
       // To access props later use this.props.name;
-      this.props.repoPrefix = repoPrefix(this.props.repository);
+      this.props.repoPrefix = repositoryPrefix(this.props.repository);
 
       this.props.moduleClassName = toClassName(this.props.moduleName);
 
@@ -128,12 +128,13 @@ module.exports = yeoman.Base.extend({
       this.templatePath('projectNameTest.jsx'),
       this.destinationPath(this.props.baseDirectory + 'tests/jest/' + this.props.jsxFileName + '.test.jsx'),
       {
-        moduleClassName: this.props.moduleClassName
+        moduleClassName: this.props.moduleClassName,
+        cssClassName: this.props.cssClassName
       }
     );
 
     this.fs.copyTpl(
-      this.templatePath('tests/**/*'),
+      this.templatePath('tests/*'),
       this.destinationPath(this.props.baseDirectory + 'tests/')
     );
 
@@ -142,7 +143,8 @@ module.exports = yeoman.Base.extend({
       this.destinationPath(this.props.baseDirectory + 'tests/nightwatch/' + this.props.moduleName + '-spec.js'),
       {
         projectName: this.props.projectName,
-        moduleName: this.props.moduleName
+        moduleName: this.props.moduleName,
+        cssClassName: this.props.cssClassName
       }
     );
 
@@ -173,7 +175,7 @@ module.exports = yeoman.Base.extend({
     );
 
     this.fs.copyTpl(
-      this.templatePath('docs/**/*'),
+      this.templatePath('docs/*'),
       this.destinationPath(this.props.baseDirectory + 'docs/'),
       {
         projectName: this.props.projectName,
@@ -185,7 +187,7 @@ module.exports = yeoman.Base.extend({
 
     this.fs.copyTpl(
       this.templatePath('Index.jsx'),
-      this.destinationPath('packages/terra-site/src/examples/' + this.props.moduleName + '/Index.jsx'),
+      this.destinationPath('packages/' + this.props.repoPrefix + '-site/src/examples/' + this.props.moduleName + '/Index.jsx'),
       {
         projectName: this.props.projectName,
         projectClassName: this.props.moduleClassName
@@ -198,12 +200,13 @@ module.exports = yeoman.Base.extend({
       {
         projectName: this.props.projectName,
         titlecaseProjectName: this.props.titlecaseProjectName,
-        currentYear: this.props.currentYear
+        currentYear: this.props.currentYear,
+        repository: this.props.repository
       }
     );
 
     this.fs.copyTpl(
-      this.templatePath('package.json'),
+      this.templatePath(this.props.repoPrefix + '-package.json'),
       this.destinationPath(this.props.baseDirectory + 'package.json'),
       {
         projectName: this.props.projectName,

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -95,7 +95,7 @@ module.exports = yeoman.Base.extend({
 
       this.props.cssClassName = toCssClassName(this.props.repoPrefix, this.props.moduleName);
 
-      this.props.baseDirectory = 'packages/' + this.props.moduleName + '/';
+      this.props.baseDirectory = 'packages/' + this.props.projectName + '/';
       this.props.jsxFileName = toClassName(this.props.moduleName);
       this.props.scssFileName = this.props.jsxFileName;
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 
 /**
  * Converts a string of the form ab bc cd into Ab Bc Cd
- * @param {String} the typically hyphenless project name
+ * @param {String} the project name
  */
 function toTitleCase(str) {
   return _.startCase(_.toLower(str));
@@ -14,29 +14,36 @@ function toTitleCase(str) {
 
 /**
  * Converts a string of the form a-b-c into ABC
- * @param {String} the project name
+ * @param {String} the project name or module name
  */
 function toClassName(str) {
   return _.upperFirst(_.camelCase(str));
 }
 
 /**
- * Converts a string of the form a-b-c into b-c
- * @param {String} the project name
+ * Concatinates strings a and b into the form a-b
+ * @param str1 {String} the repository name
+ * @param str2 {String} the module name
  */
-function namespacelessProjectName(str) {
-  var hyphenlessProjectNameArray = str.split("-");
-  hyphenlessProjectNameArray.shift();
-  return hyphenlessProjectNameArray.join("-");
+function toProjectName(str1, str2) {
+  return str1 + '-' + str2;
 }
 
 /**
- * Converts a string of the form a-b-c into a-BC
- * @param {String} the project name
+ * Concatinates strings a-b and c-d into the form aB-CD
+ * @param str1 {String} the repository name
+ * @param str2 {String} the module name
  */
-function toCssClassName(str) {
-  const namespaceless = namespacelessProjectName(str);
-  return str.replace(namespaceless, toClassName(namespaceless));
+function toCssClassName(str1, str2) {
+  return toProjectName(_.camelCase(str1), toClassName(str2));
+}
+
+/**
+ * Returns the repository prefix
+ * @param {String} the repository name
+ */
+function repoPrefix(repo) {
+  return (repo === 'terra-core') ? 'terra' : repo;
 }
 
 module.exports = yeoman.Base.extend({
@@ -58,9 +65,18 @@ module.exports = yeoman.Base.extend({
 
     var prompts = [{
       type: 'input',
-      name: 'projectName',
+      name: 'repository',
+      message: 'Terra repository:',
+      default: 'terra-core',
+      validate: function (input) {
+        var validRepos = ['terra-core', 'terra-clinical'];
+        return input !== undefined && validRepos.includes(input);
+      }
+    }, {
+      type: 'input',
+      name: 'moduleName',
       message: 'Your module name:',
-      default: this.projectName,
+      default: this.moduleName,
       validate: function (input) {
         return input !== undefined && input.length !== 0;
       }
@@ -69,15 +85,20 @@ module.exports = yeoman.Base.extend({
     this.prompt(prompts, function (props) {
       this.props = props;
       // To access props later use this.props.name;
+      this.props.repoPrefix = repoPrefix(this.props.repository);
 
-      this.props.cssClassName = toCssClassName(this.props.projectName);
-      this.props.namespacelessProjectName = namespacelessProjectName(this.props.projectName);
-      this.props.namespacelessProjectClassName = toClassName(namespacelessProjectName(this.props.projectName));
+      this.props.moduleClassName = toClassName(this.props.moduleName);
+
+      this.props.projectName = toProjectName(this.props.repoPrefix, this.props.moduleName);
       this.props.projectClassName = toClassName(this.props.projectName);
       this.props.titlecaseProjectName = toTitleCase(this.props.projectName.replace('-', ' '));
-      this.props.jsxFileName = toClassName(namespacelessProjectName(this.props.projectName));
+
+      this.props.cssClassName = toCssClassName(this.props.repoPrefix, this.props.moduleName);
+
+      this.props.baseDirectory = 'packages/' + this.props.moduleName + '/';
+      this.props.jsxFileName = toClassName(this.props.moduleName);
       this.props.scssFileName = this.props.jsxFileName;
-      this.props.baseDirectory = 'packages/' + this.props.projectName + '/';
+
       this.props.currentYear = new Date().getFullYear();
 
       done();
@@ -90,8 +111,8 @@ module.exports = yeoman.Base.extend({
       this.destinationPath(this.props.baseDirectory + 'src/' + this.props.jsxFileName + '.jsx'),
       {
         scssFileName: this.props.scssFileName,
-        projectClassName: this.props.namespacelessProjectClassName,
-        projectCssClassName: this.props.cssClassName
+        moduleClassName: this.props.moduleClassName,
+        cssClassName: this.props.cssClassName
       }
     );
 
@@ -99,7 +120,7 @@ module.exports = yeoman.Base.extend({
       this.templatePath('src/projectName.scss'),
       this.destinationPath(this.props.baseDirectory + 'src/' + this.props.scssFileName + '.scss'),
       {
-        projectCssClassName: this.props.cssClassName
+        cssClassName: this.props.cssClassName
       }
     );
 
@@ -107,9 +128,7 @@ module.exports = yeoman.Base.extend({
       this.templatePath('projectNameTest.jsx'),
       this.destinationPath(this.props.baseDirectory + 'tests/jest/' + this.props.jsxFileName + '.test.jsx'),
       {
-        namespacelessProjectClassName: this.props.namespacelessProjectClassName,
-        projectClassName: this.props.projectClassName,
-        projectCssClassName: this.props.cssClassName
+        moduleClassName: this.props.moduleClassName
       }
     );
 
@@ -120,37 +139,36 @@ module.exports = yeoman.Base.extend({
 
     this.fs.copyTpl(
       this.templatePath('projectName-spec.js'),
-      this.destinationPath(this.props.baseDirectory + 'tests/nightwatch/' + this.props.namespacelessProjectName + '-spec.js'),
+      this.destinationPath(this.props.baseDirectory + 'tests/nightwatch/' + this.props.moduleName + '-spec.js'),
       {
         projectName: this.props.projectName,
-        namespacelessProjectName: this.props.namespacelessProjectName,
-        projectCssClassName: this.props.cssClassName
+        moduleName: this.props.moduleName
       }
     );
 
     this.fs.copyTpl(
       this.templatePath('projectNameTestRoutes.jsx'),
-      this.destinationPath(this.props.baseDirectory + 'tests/nightwatch/' + this.props.namespacelessProjectClassName + 'TestRoutes.jsx'),
+      this.destinationPath(this.props.baseDirectory + 'tests/nightwatch/' + this.props.moduleClassName + 'TestRoutes.jsx'),
       {
-        namespacelessProjectName: this.props.namespacelessProjectName,
-        namespacelessProjectClassName: this.props.namespacelessProjectClassName
+        moduleName: this.props.moduleName,
+        moduleClassName: this.props.moduleClassName
       }
     );
 
     this.fs.copyTpl(
       this.templatePath('projectNameTests.jsx'),
-      this.destinationPath(this.props.baseDirectory + 'tests/nightwatch/' + this.props.namespacelessProjectClassName + 'Tests.jsx'),
+      this.destinationPath(this.props.baseDirectory + 'tests/nightwatch/' + this.props.moduleClassName + 'Tests.jsx'),
       {
-        namespacelessProjectName: this.props.namespacelessProjectName,
-        namespacelessProjectClassName: this.props.namespacelessProjectClassName
+        moduleName: this.props.moduleName,
+        moduleClassName: this.props.moduleClassName
       }
     );
 
     this.fs.copyTpl(
       this.templatePath('DefaultProjectName.jsx'),
-      this.destinationPath(this.props.baseDirectory + 'tests/nightwatch/Default' + this.props.namespacelessProjectClassName + '.jsx'),
+      this.destinationPath(this.props.baseDirectory + 'tests/nightwatch/Default' + this.props.moduleClassName + '.jsx'),
       {
-        namespacelessProjectClassName: this.props.namespacelessProjectClassName
+        moduleClassName: this.props.moduleClassName
       }
     );
 
@@ -159,7 +177,7 @@ module.exports = yeoman.Base.extend({
       this.destinationPath(this.props.baseDirectory + 'docs/'),
       {
         projectName: this.props.projectName,
-        projectClassName: this.props.namespacelessProjectClassName,
+        projectClassName: this.props.moduleClassName,
         titlecaseProjectName: this.props.titlecaseProjectName,
         currentYear: this.props.currentYear
       }
@@ -167,10 +185,10 @@ module.exports = yeoman.Base.extend({
 
     this.fs.copyTpl(
       this.templatePath('Index.jsx'),
-      this.destinationPath('packages/terra-site/src/examples/' + this.props.namespacelessProjectName + '/Index.jsx'),
+      this.destinationPath('packages/terra-site/src/examples/' + this.props.moduleName + '/Index.jsx'),
       {
         projectName: this.props.projectName,
-        projectClassName: this.props.namespacelessProjectClassName
+        projectClassName: this.props.moduleClassName
       }
     );
 

--- a/generators/app/templates/DefaultProjectName.jsx
+++ b/generators/app/templates/DefaultProjectName.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-import <%= namespacelessProjectClassName %> from '../../lib/<%= namespacelessProjectClassName %>';
+import <%= moduleClassName %> from '../../lib/<%= moduleClassName %>';
 
-export default () => <<%= namespacelessProjectClassName %> />;
+export default () => <<%= moduleClassName %> />;

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -2,12 +2,12 @@
 
 
 [![NPM version](http://img.shields.io/npm/v/<%= projectName %>.svg)](https://www.npmjs.org/package/<%= projectName %>)
-[![Build Status](https://travis-ci.org/cerner/terra-core.svg?branch=master)](https://travis-ci.org/cerner/terra-core)
+[![Build Status](https://travis-ci.org/cerner/<%= repository %>.svg?branch=master)](https://travis-ci.org/cerner/<%= repository %>)
 
 {insert description}
 
 - [Getting Started](#getting-started)
-- [Documentation](https://github.com/cerner/terra-core/tree/master/packages/<%= projectName %>/docs)
+- [Documentation](https://github.com/cerner/<%= repository %>/tree/master/packages/<%= projectName %>/docs)
 - [LICENSE](#license)
 
 ## Getting Started

--- a/generators/app/templates/docs/README.md
+++ b/generators/app/templates/docs/README.md
@@ -14,5 +14,5 @@
 import React from 'react';
 import <%= projectClassName %> from '<%= projectName %>';
 
-<<%= projectClassName %> {props.......} />
+<<%= projectClassName %> {props...} />
 ```

--- a/generators/app/templates/docs/README.md
+++ b/generators/app/templates/docs/README.md
@@ -6,7 +6,6 @@
 
 - Install with [npmjs](https://www.npmjs.com):
   - `npm install <%= projectName %>`
-  - `yarn add <%= projectName %>`
 
 ## Usage
 

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -3,7 +3,7 @@
   "main": "lib/<%=jsxFileName%>.js",
   "private": true,
   "version": "0.0.0",
-  "description": "<%=projectName%>",
+  "description": "{insert description}",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cerner/terra-core.git"

--- a/generators/app/templates/projectName-spec.js
+++ b/generators/app/templates/projectName-spec.js
@@ -13,7 +13,7 @@ module.exports = {
 
   'Displays a default button with the provided text': (browser) => {
     browser
-      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/<%= namespacelessProjectName %>-tests/default`);
+      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/<%= moduleName %>-tests/default`);
   },
 };
 

--- a/generators/app/templates/projectName-spec.js
+++ b/generators/app/templates/projectName-spec.js
@@ -11,9 +11,9 @@ module.exports = {
     screenshot(browser, '<%= projectName %>', done);
   },
 
-  'Displays a default button with the provided text': (browser) => {
+  'Displays a default <%= moduleName %>': (browser) => {
     browser
-      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/<%= moduleName %>-tests/default`);
+      .url(`http://localhost:${browser.globals.webpackDevServerPort}/#/tests/<%= moduleName %>-tests/default`)
+      .assert.elementPresent('.<%= cssClassName %>');
   },
 };
-

--- a/generators/app/templates/projectNameTest.jsx
+++ b/generators/app/templates/projectNameTest.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import <%= namespacelessProjectClassName %> from '../../src/<%= namespacelessProjectClassName %>';
+import <%= moduleClassName %> from '../../src/<%= moduleClassName %>';
 
 it('should render a default component', () => {
   expect(1).toEqual(1);

--- a/generators/app/templates/projectNameTest.jsx
+++ b/generators/app/templates/projectNameTest.jsx
@@ -1,6 +1,24 @@
 import React from 'react';
 import <%= moduleClassName %> from '../../src/<%= moduleClassName %>';
 
-it('should render a default component', () => {
-  expect(1).toEqual(1);
+describe('<%= moduleClassName %>', () => {
+  const defaultRender = <<%= moduleClassName %> />;
+
+  // Snapshot Tests
+  it('should render a default component', () => {
+    const wrapper = shallow(defaultRender);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  // Prop Tests
+  it('should use the default value when no value is given', () => {
+    const wrapper = shallow(defaultRender);
+    expect(wrapper.find('.<%= cssClassName %>').text()).toEqual('defualt');
+  });
+
+  // Structure Tests
+  it('should have the class <%= cssClassName %>', () => {
+    const wrapper = shallow(defaultRender);
+    expect(wrapper.prop('className')).toContain('<%= cssClassName %>');
+  });
 });

--- a/generators/app/templates/projectNameTestRoutes.jsx
+++ b/generators/app/templates/projectNameTestRoutes.jsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { Route } from 'react-router';
 import <%= moduleClassName %>Tests from './<%= moduleClassName %>Tests';
+
+// Test Cases
 import Default<%= moduleClassName %> from './Default<%= moduleClassName %>';
 
 const routes = (

--- a/generators/app/templates/projectNameTestRoutes.jsx
+++ b/generators/app/templates/projectNameTestRoutes.jsx
@@ -2,13 +2,13 @@
 
 import React from 'react';
 import { Route } from 'react-router';
-import <%= namespacelessProjectClassName %>Tests from './<%= namespacelessProjectClassName %>Tests';
-import Default<%= namespacelessProjectClassName %> from './Default<%= namespacelessProjectClassName %>';
+import <%= moduleClassName %>Tests from './<%= moduleClassName %>Tests';
+import Default<%= moduleClassName %> from './Default<%= moduleClassName %>';
 
 const routes = (
   <div>
-    <Route path="/tests/<%= namespacelessProjectName %>-tests" component={<%= namespacelessProjectClassName %>Tests} />
-    <Route path="/tests/<%= namespacelessProjectName %>-tests/default" component={Default<%= namespacelessProjectClassName %>} />
+    <Route path="/tests/<%= moduleName %>-tests" component={<%= moduleClassName %>Tests} />
+    <Route path="/tests/<%= moduleName %>-tests/default" component={Default<%= moduleClassName %>} />
   </div>
 );
 

--- a/generators/app/templates/projectNameTests.jsx
+++ b/generators/app/templates/projectNameTests.jsx
@@ -3,12 +3,12 @@
 import React from 'react';
 import { Link } from 'react-router';
 
-const <%= namespacelessProjectClassName %>Tests = () => (
+const <%= moduleClassName %>Tests = () => (
   <div>
     <ul>
-      <li><Link to="/tests/<%= namespacelessProjectName %>-tests/default">Default <%= namespacelessProjectClassName %></Link></li>
+      <li><Link to="/tests/<%= moduleName %>-tests/default">Default <%= moduleClassName %></Link></li>
     </ul>
   </div>
 );
 
-export default <%= namespacelessProjectClassName %>Tests;
+export default <%= moduleClassName %>Tests;

--- a/generators/app/templates/src/projectName.jsx
+++ b/generators/app/templates/src/projectName.jsx
@@ -9,14 +9,14 @@ const propTypes = {
 
 const defaultProps = {
   name: 'default',
-  variant: '<%= projectCssClassName %>--default',
+  variant: '<%= cssClassName %>--default',
 };
 
-const <%= projectClassName %> = (props) => (
+const <%= moduleClassName %> = (props) => (
   <div />
 );
 
-<%= projectClassName %>.propTypes = propTypes;
-<%= projectClassName %>.defaultProps = defaultProps;
+<%= moduleClassName %>.propTypes = propTypes;
+<%= moduleClassName %>.defaultProps = defaultProps;
 
-export default <%= projectClassName %>;
+export default <%= moduleClassName %>;

--- a/generators/app/templates/src/projectName.jsx
+++ b/generators/app/templates/src/projectName.jsx
@@ -1,20 +1,29 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import 'terra-base/lib/baseStyles';
 import './<%= scssFileName %>.scss';
 
 const propTypes = {
-  name: PropTypes.string.isRequired,
-  variant: PropTypes.string.isRequired,
+ /*
+ * Content to be displayed as the name
+ */
+  name: PropTypes.string,
 };
 
 const defaultProps = {
   name: 'default',
-  variant: '<%= cssClassName %>--default',
 };
 
-const <%= moduleClassName %> = (props) => (
-  <div />
-);
+const <%= moduleClassName %> = ({ name, ...customProps }) => {
+  const attributes = Object.assign({}, customProps);
+  const <%= moduleClassName %>ClassNames = classNames([
+    '<%= cssClassName %>',
+    attributes.className,
+  ]);
+
+  return (<div {...attributes} className={<%= moduleClassName %>ClassNames} />)
+};
 
 <%= moduleClassName %>.propTypes = propTypes;
 <%= moduleClassName %>.defaultProps = defaultProps;

--- a/generators/app/templates/src/projectName.scss
+++ b/generators/app/templates/src/projectName.scss
@@ -1,3 +1,7 @@
 @import '~terra-mixins';
 @import './variables';
 @import './mixins';
+
+.<%= cssClassName %> {
+
+}

--- a/generators/app/templates/terra-clinical-package.json
+++ b/generators/app/templates/terra-clinical-package.json
@@ -28,12 +28,12 @@
   "peerDependencies": {
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "prop-types": "^15.5.8",
     "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "prop-types": "^15.5.8",
     "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },

--- a/generators/app/templates/terra-clinical-package.json
+++ b/generators/app/templates/terra-clinical-package.json
@@ -1,0 +1,60 @@
+{
+  "name": "<%=projectName%>",
+  "main": "lib/<%=jsxFileName%>.js",
+  "private": true,
+  "version": "0.0.0",
+  "description": "{insert description}",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cerner/terra-clinical.git"
+  },
+  "keywords": [
+    "Cerner",
+    "Terra",
+    "Clinical",
+    "<%=projectName%>",
+    "<%=jsxFileName%>",
+    "UI"
+  ],
+  "author": "Cerner Corporation",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/cerner/terra-clinical/issues"
+  },
+  "homepage": "https://github.com/cerner/terra-clinical#readme",
+  "devDependencies": {
+    "terra-toolkit": "^0.x"
+  },
+  "peerDependencies": {
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "prop-types": "^15.5.6",
+    "terra-base": "^0.x",
+    "terra-mixins": "^1.0.0"
+  },
+  "dependencies": {
+    "classnames": "^2.2.5",
+    "terra-base": "^0.x",
+    "terra-mixins": "^1.0.0"
+  },
+  "scripts": {
+    "compile": "npm run compile:clean && npm run compile:build",
+    "compile:clean": "$(cd ..; npm bin)/rimraf lib",
+    "compile:build": "$(cd ..; npm bin)/babel src --out-dir lib --copy-files",
+    "lint": "npm run lint:js && npm run lint:scss",
+    "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
+    "lint:scss": "$(cd ..; npm bin)/stylelint src/**/*.scss",
+    "release:major": "npm test && node ../../scripts/release/release.js major",
+    "release:minor": "npm test && node ../../scripts/release/release.js minor",
+    "release:patch": "npm test && node ../../scripts/release/release.js patch",
+    "test": "npm run test:spec && npm run test:nightwatch-default",
+    "test:spec": "$(cd ..; npm bin)/jest --config ../../jestconfig.json",
+    "test:all": "npm run test:nightwatch-default && npm run test:nightwatch-chrome && npm run test:nightwatch-firefox && npm run test:nightwatch-safari",
+    "test:nightwatch-default": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=<%= projectName %> node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js",
+    "test:nightwatch-chrome": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=<%= projectName %> node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js chrome",
+    "test:nightwatch-firefox": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=<%= projectName %> node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js firefox",
+    "test:nightwatch-safari": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=<%= projectName %> node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari",
+    "test:remote": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=<%= projectName %> REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js",
+    "test:remote:all": "WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config SPECTRE_TEST_SUITE=<%= projectName %> REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js --env chrome-tiny,chrome-small,chrome-medium,chrome-large,chrome-huge,chrome-enormous,firefox-tiny,firefox-small,firefox-medium,firefox-large,firefox-huge,firefox-enormous,ie10-tiny,ie10-small,ie10-medium,ie10-large,ie10-huge,ie10-enormous,ie11-tiny,ie11-small,ie11-medium,ie11-large,ie11-huge,ie11-enormous,edge-tiny,edge-small,edge-medium,edge-large,edge-huge,edge-enormous,safari-tiny,safari-small,safari-medium,safari-large,safari-huge,safari-enormous"
+  }
+}

--- a/generators/app/templates/terra-clinical-package.json
+++ b/generators/app/templates/terra-clinical-package.json
@@ -26,9 +26,9 @@
     "terra-toolkit": "^0.x"
   },
   "peerDependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "prop-types": "^15.5.6",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "prop-types": "^15.5.8",
     "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },

--- a/generators/app/templates/terra-package.json
+++ b/generators/app/templates/terra-package.json
@@ -25,9 +25,9 @@
     "terra-toolkit": "^0.x"
   },
   "peerDependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "prop-types": "^15.5.6",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "prop-types": "^15.5.8",
     "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },

--- a/generators/app/templates/terra-package.json
+++ b/generators/app/templates/terra-package.json
@@ -26,16 +26,19 @@
   },
   "peerDependencies": {
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "prop-types": "^15.5.6",
+    "terra-base": "^0.x",
+    "terra-mixins": "^1.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "react": "^15.4.2",
+    "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",
-    "compile:clean": "rm -rf lib",
+    "compile:clean": "$(cd ..; npm bin)/rimraf lib",
     "compile:build": "$(cd ..; npm bin)/babel src --out-dir lib --copy-files",
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "$(cd ..; npm bin)/eslint --ext .js,.jsx . --ignore-path ../../.eslintignore",
@@ -49,6 +52,8 @@
     "test:nightwatch-default": "SPECTRE_TEST_SUITE=<%= projectName %> node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js",
     "test:nightwatch-chrome": "SPECTRE_TEST_SUITE=<%= projectName %> node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js chrome",
     "test:nightwatch-firefox": "SPECTRE_TEST_SUITE=<%= projectName %> node ./node_modules/terra-toolkit/lib/scripts/nightwatch.js firefox",
-    "test:nightwatch-safari": "SPECTRE_TEST_SUITE=<%= projectName %> node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari"
+    "test:nightwatch-safari": "SPECTRE_TEST_SUITE=<%= projectName %> node ./node_modules/terra-toolkit/lib/scripts/nightwatch-non-parallel.js safari",
+    "test:remote": "SPECTRE_TEST_SUITE=<%= projectName %> REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js",
+    "test:remote:all": "SPECTRE_TEST_SUITE=<%= projectName %> REMOTE=true node ./node_modules/terra-toolkit/lib/scripts/nightwatch-process.js --config tests/nightwatch.conf.js --env chrome-tiny,chrome-small,chrome-medium,chrome-large,chrome-huge,chrome-enormous,firefox-tiny,firefox-small,firefox-medium,firefox-large,firefox-huge,firefox-enormous,ie10-tiny,ie10-small,ie10-medium,ie10-large,ie10-huge,ie10-enormous,ie11-tiny,ie11-small,ie11-medium,ie11-large,ie11-huge,ie11-enormous,edge-tiny,edge-small,edge-medium,edge-large,edge-huge,edge-enormous,safari-tiny,safari-small,safari-medium,safari-large,safari-huge,safari-enormous"
   }
 }

--- a/generators/app/templates/terra-package.json
+++ b/generators/app/templates/terra-package.json
@@ -27,12 +27,12 @@
   "peerDependencies": {
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "prop-types": "^15.5.8",
     "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
+    "prop-types": "^15.5.8",
     "terra-base": "^0.x",
     "terra-mixins": "^1.0.0"
   },

--- a/test/app.js
+++ b/test/app.js
@@ -17,46 +17,46 @@ describe('generator-terra-module:app', function () {
 
     it('creates files', function () {
       assert.file([
-        'packages/waffle-cake/README.md',
+        'packages/terra-waffle-cake/README.md',
         'packages/terra-site/src/examples/waffle-cake/Index.jsx'
       ]);
     });
 
     it('creates the mixins and variables files', function () {
       assert.file([
-        'packages/waffle-cake/src/_mixins.scss',
-        'packages/waffle-cake/src/_variables.scss'
+        'packages/terra-waffle-cake/src/_mixins.scss',
+        'packages/terra-waffle-cake/src/_variables.scss'
       ]);
     });
 
     it('creates the License and Notice files', function () {
       assert.file([
-        'packages/waffle-cake/LICENSE',
-        'packages/waffle-cake/NOTICE'
+        'packages/terra-waffle-cake/LICENSE',
+        'packages/terra-waffle-cake/NOTICE'
       ]);
     });
 
     it('fills the sass file with some dummy sass', function () {
-      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '@import \'./variables\';');
-      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '@import \'./mixins\';');
-      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '.terra-WaffleCake {');
+      assert.fileContent('packages/terra-waffle-cake/src/WaffleCake.scss', '@import \'./variables\';');
+      assert.fileContent('packages/terra-waffle-cake/src/WaffleCake.scss', '@import \'./mixins\';');
+      assert.fileContent('packages/terra-waffle-cake/src/WaffleCake.scss', '.terra-WaffleCake {');
     });
 
     it('fills the docs/README file with title cased project data', function () {
-      assert.fileContent('packages/waffle-cake/docs/README.md', 'Terra Waffle Cake');
+      assert.fileContent('packages/terra-waffle-cake/docs/README.md', 'Terra Waffle Cake');
     });
 
     it('fills the package.json file with project data', function () {
-      assert.fileContent('packages/waffle-cake/package.json', 'git+https://github.com/cerner/terra-core.git');
-      assert.fileContent('packages/waffle-cake/package.json', 'https://github.com/cerner/terra-core/issues');
+      assert.fileContent('packages/terra-waffle-cake/package.json', 'git+https://github.com/cerner/terra-core.git');
+      assert.fileContent('packages/terra-waffle-cake/package.json', 'https://github.com/cerner/terra-core/issues');
     });
 
     it('fills the README file with project data', function () {
-      assert.fileContent('packages/waffle-cake/README.md', '# Terra Waffle Cake');
-      assert.fileContent('packages/waffle-cake/README.md', 'img.shields.io/npm/v/terra-waffle-cake.svg');
-      assert.fileContent('packages/waffle-cake/README.md', 'travis-ci.org/cerner/terra-core.svg');
-      assert.fileContent('packages/waffle-cake/README.md', 'npm install terra-waffle-cake');
-      assert.fileContent('packages/waffle-cake/README.md', '[Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-waffle-cake/docs)');
+      assert.fileContent('packages/terra-waffle-cake/README.md', '# Terra Waffle Cake');
+      assert.fileContent('packages/terra-waffle-cake/README.md', 'img.shields.io/npm/v/terra-waffle-cake.svg');
+      assert.fileContent('packages/terra-waffle-cake/README.md', 'travis-ci.org/cerner/terra-core.svg');
+      assert.fileContent('packages/terra-waffle-cake/README.md', 'npm install terra-waffle-cake');
+      assert.fileContent('packages/terra-waffle-cake/README.md', '[Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-waffle-cake/docs)');
     });
 
     it('fills the examples Index file with project data', function () {
@@ -68,9 +68,9 @@ describe('generator-terra-module:app', function () {
     });
 
     it('fills the examples Index file with project data', function () {
-      assert.fileContent('packages/waffle-cake/.npmignore', `src`);
-      assert.fileContent('packages/waffle-cake/.npmignore', `node_modules`);
-      assert.fileContent('packages/waffle-cake/.npmignore', `*.log`);
+      assert.fileContent('packages/terra-waffle-cake/.npmignore', `src`);
+      assert.fileContent('packages/terra-waffle-cake/.npmignore', `node_modules`);
+      assert.fileContent('packages/terra-waffle-cake/.npmignore', `*.log`);
     });
   });
 
@@ -87,47 +87,47 @@ describe('generator-terra-module:app', function () {
 
     it('creates files', function () {
       assert.file([
-        'packages/monster-cookies/README.md',
+        'packages/terra-clinical-monster-cookies/README.md',
         'packages/terra-clinical-site/src/examples/monster-cookies/Index.jsx'
       ]);
     });
 
     it('creates the mixins and variables files', function () {
       assert.file([
-        'packages/monster-cookies/src/_mixins.scss',
-        'packages/monster-cookies/src/_variables.scss'
+        'packages/terra-clinical-monster-cookies/src/_mixins.scss',
+        'packages/terra-clinical-monster-cookies/src/_variables.scss'
       ]);
     });
 
     it('creates the License and Notice files', function () {
       assert.file([
-        'packages/monster-cookies/LICENSE',
-        'packages/monster-cookies/NOTICE'
+        'packages/terra-clinical-monster-cookies/LICENSE',
+        'packages/terra-clinical-monster-cookies/NOTICE'
       ]);
     });
 
     it('fills the sass file with some dummy sass', function () {
-      assert.fileContent('packages/monster-cookies/src/MonsterCookies.scss', '@import \'./variables\';');
-      assert.fileContent('packages/monster-cookies/src/MonsterCookies.scss', '@import \'./mixins\';');
-      assert.fileContent('packages/monster-cookies/src/MonsterCookies.scss', '.terraClinical-MonsterCookies {');
+      assert.fileContent('packages/terra-clinical-monster-cookies/src/MonsterCookies.scss', '@import \'./variables\';');
+      assert.fileContent('packages/terra-clinical-monster-cookies/src/MonsterCookies.scss', '@import \'./mixins\';');
+      assert.fileContent('packages/terra-clinical-monster-cookies/src/MonsterCookies.scss', '.terraClinical-MonsterCookies {');
     });
 
     it('fills the docs/README file with title cased project data', function () {
-      assert.fileContent('packages/monster-cookies/docs/README.md', 'Terra Clinical Monster Cookies');
+      assert.fileContent('packages/terra-clinical-monster-cookies/docs/README.md', 'Terra Clinical Monster Cookies');
     });
 
     it('fills the package.json file with project data', function () {
-      assert.fileContent('packages/monster-cookies/package.json', 'git+https://github.com/cerner/terra-clinical.git');
-      assert.fileContent('packages/monster-cookies/package.json', 'https://github.com/cerner/terra-clinical/issues');
-      assert.fileContent('packages/monster-cookies/package.json', 'WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config');
+      assert.fileContent('packages/terra-clinical-monster-cookies/package.json', 'git+https://github.com/cerner/terra-clinical.git');
+      assert.fileContent('packages/terra-clinical-monster-cookies/package.json', 'https://github.com/cerner/terra-clinical/issues');
+      assert.fileContent('packages/terra-clinical-monster-cookies/package.json', 'WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config');
     });
 
     it('fills the README file with project data', function () {
-      assert.fileContent('packages/monster-cookies/README.md', '# Terra Clinical Monster Cookies');
-      assert.fileContent('packages/monster-cookies/README.md', 'img.shields.io/npm/v/terra-clinical-monster-cookies.svg');
-      assert.fileContent('packages/monster-cookies/README.md', 'travis-ci.org/cerner/terra-clinical.svg');
-      assert.fileContent('packages/monster-cookies/README.md', 'npm install terra-clinical-monster-cookies');
-      assert.fileContent('packages/monster-cookies/README.md', '[Documentation](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-monster-cookies/docs)');
+      assert.fileContent('packages/terra-clinical-monster-cookies/README.md', '# Terra Clinical Monster Cookies');
+      assert.fileContent('packages/terra-clinical-monster-cookies/README.md', 'img.shields.io/npm/v/terra-clinical-monster-cookies.svg');
+      assert.fileContent('packages/terra-clinical-monster-cookies/README.md', 'travis-ci.org/cerner/terra-clinical.svg');
+      assert.fileContent('packages/terra-clinical-monster-cookies/README.md', 'npm install terra-clinical-monster-cookies');
+      assert.fileContent('packages/terra-clinical-monster-cookies/README.md', '[Documentation](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-monster-cookies/docs)');
     });
 
     it('fills the examples Index file with project data', function () {
@@ -139,9 +139,9 @@ describe('generator-terra-module:app', function () {
     });
 
     it('fills the examples Index file with project data', function () {
-      assert.fileContent('packages/monster-cookies/.npmignore', `src`);
-      assert.fileContent('packages/monster-cookies/.npmignore', `node_modules`);
-      assert.fileContent('packages/monster-cookies/.npmignore', `*.log`);
+      assert.fileContent('packages/terra-clinical-monster-cookies/.npmignore', `src`);
+      assert.fileContent('packages/terra-clinical-monster-cookies/.npmignore', `node_modules`);
+      assert.fileContent('packages/terra-clinical-monster-cookies/.npmignore', `*.log`);
     });
   });
 });

--- a/test/app.js
+++ b/test/app.js
@@ -66,69 +66,11 @@ describe('generator-terra-module:app', function () {
       assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import { version } from 'terra-waffle-cake/package.json';`);
       assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `export default WaffleCakeExamples;`);
     });
-  });
-
-  describe('terra-core module', function () {
-    before(function (done) {
-      helpers.run(path.join(__dirname, '../generators/app'))
-        .withPrompts({
-          repository: 'terra-core',
-          moduleName: 'waffle-cake',
-          curentYear: '1000'
-        })
-        .on('end', done);
-    });
-
-    it('creates files', function () {
-      assert.file([
-        'packages/waffle-cake/README.md',
-        'packages/terra-site/src/examples/waffle-cake/Index.jsx'
-      ]);
-    });
-
-    it('creates the mixins and variables files', function () {
-      assert.file([
-        'packages/waffle-cake/src/_mixins.scss',
-        'packages/waffle-cake/src/_variables.scss'
-      ]);
-    });
-
-    it('creates the License and Notice files', function () {
-      assert.file([
-        'packages/waffle-cake/LICENSE',
-        'packages/waffle-cake/NOTICE'
-      ]);
-    });
-
-    it('fills the sass file with some dummy sass', function () {
-      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '@import \'./variables\';');
-      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '@import \'./mixins\';');
-      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '.terra-WaffleCake {');
-    });
-
-    it('fills the docs/README file with title cased project data', function () {
-      assert.fileContent('packages/waffle-cake/docs/README.md', 'Terra Waffle Cake');
-    });
-
-    it('fills the package.json file with project data', function () {
-      assert.fileContent('packages/waffle-cake/package.json', 'git+https://github.com/cerner/terra-core.git');
-      assert.fileContent('packages/waffle-cake/package.json', 'https://github.com/cerner/terra-core/issues');
-    });
-
-    it('fills the README file with project data', function () {
-      assert.fileContent('packages/waffle-cake/README.md', '# Terra Waffle Cake');
-      assert.fileContent('packages/waffle-cake/README.md', 'img.shields.io/npm/v/terra-waffle-cake.svg');
-      assert.fileContent('packages/waffle-cake/README.md', 'travis-ci.org/cerner/terra-core.svg');
-      assert.fileContent('packages/waffle-cake/README.md', 'npm install terra-waffle-cake');
-      assert.fileContent('packages/waffle-cake/README.md', '[Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-waffle-cake/docs)');
-    });
 
     it('fills the examples Index file with project data', function () {
-      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import React from 'react';`);
-      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import WaffleCakeSrc from '!raw-loader!terra-waffle-cake/src/WaffleCake';`);
-      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import ReadMe from 'terra-waffle-cake/docs/README.md';`);
-      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import { version } from 'terra-waffle-cake/package.json';`);
-      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `export default WaffleCakeExamples;`);
+      assert.fileContent('packages/waffle-cake/.npmignore', `src`);
+      assert.fileContent('packages/waffle-cake/.npmignore', `node_modules`);
+      assert.fileContent('packages/waffle-cake/.npmignore', `*.log`);
     });
   });
 
@@ -195,11 +137,11 @@ describe('generator-terra-module:app', function () {
       assert.fileContent('packages/terra-clinical-site/src/examples/monster-cookies/Index.jsx', `import { version } from 'terra-clinical-monster-cookies/package.json';`);
       assert.fileContent('packages/terra-clinical-site/src/examples/monster-cookies/Index.jsx', `export default MonsterCookiesExamples;`);
     });
-  });
 
-  it('fills the examples Index file with project data', function () {
-    assert.fileContent('packages/waffle-cake/.npmignore', `src`);
-    assert.fileContent('packages/waffle-cake/.npmignore', `node_modules`);
-    assert.fileContent('packages/waffle-cake/.npmignore', `*.log`);
+    it('fills the examples Index file with project data', function () {
+      assert.fileContent('packages/monster-cookies/.npmignore', `src`);
+      assert.fileContent('packages/monster-cookies/.npmignore', `node_modules`);
+      assert.fileContent('packages/monster-cookies/.npmignore', `*.log`);
+    });
   });
 });

--- a/test/app.js
+++ b/test/app.js
@@ -4,56 +4,196 @@ var assert = require('yeoman-assert');
 var helpers = require('yeoman-test');
 
 describe('generator-terra-module:app', function () {
-  before(function (done) {
-    helpers.run(path.join(__dirname, '../generators/app'))
-      .withPrompts({
-        projectName: 'waffle-cake',
-        curentYear: '1000'
-      })
-      .on('end', done);
+  describe('terra-core module', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../generators/app'))
+        .withPrompts({
+          repository: 'terra-core',
+          moduleName: 'waffle-cake',
+          curentYear: '1000'
+        })
+        .on('end', done);
+    });
+
+    it('creates files', function () {
+      assert.file([
+        'packages/waffle-cake/README.md',
+        'packages/terra-site/src/examples/waffle-cake/Index.jsx'
+      ]);
+    });
+
+    it('creates the mixins and variables files', function () {
+      assert.file([
+        'packages/waffle-cake/src/_mixins.scss',
+        'packages/waffle-cake/src/_variables.scss'
+      ]);
+    });
+
+    it('creates the License and Notice files', function () {
+      assert.file([
+        'packages/waffle-cake/LICENSE',
+        'packages/waffle-cake/NOTICE'
+      ]);
+    });
+
+    it('fills the sass file with some dummy sass', function () {
+      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '@import \'./variables\';');
+      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '@import \'./mixins\';');
+      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '.terra-WaffleCake {');
+    });
+
+    it('fills the docs/README file with title cased project data', function () {
+      assert.fileContent('packages/waffle-cake/docs/README.md', 'Terra Waffle Cake');
+    });
+
+    it('fills the package.json file with project data', function () {
+      assert.fileContent('packages/waffle-cake/package.json', 'git+https://github.com/cerner/terra-core.git');
+      assert.fileContent('packages/waffle-cake/package.json', 'https://github.com/cerner/terra-core/issues');
+    });
+
+    it('fills the README file with project data', function () {
+      assert.fileContent('packages/waffle-cake/README.md', '# Terra Waffle Cake');
+      assert.fileContent('packages/waffle-cake/README.md', 'img.shields.io/npm/v/terra-waffle-cake.svg');
+      assert.fileContent('packages/waffle-cake/README.md', 'travis-ci.org/cerner/terra-core.svg');
+      assert.fileContent('packages/waffle-cake/README.md', 'npm install terra-waffle-cake');
+      assert.fileContent('packages/waffle-cake/README.md', '[Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-waffle-cake/docs)');
+    });
+
+    it('fills the examples Index file with project data', function () {
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import React from 'react';`);
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import WaffleCakeSrc from '!raw-loader!terra-waffle-cake/src/WaffleCake';`);
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import ReadMe from 'terra-waffle-cake/docs/README.md';`);
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import { version } from 'terra-waffle-cake/package.json';`);
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `export default WaffleCakeExamples;`);
+    });
   });
 
-  it('creates files', function () {
-    assert.file([
-      'packages/waffle-cake/README.md',
-      'packages/terra-site/src/examples/cake/Index.jsx'
-    ]);
+  describe('terra-core module', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../generators/app'))
+        .withPrompts({
+          repository: 'terra-core',
+          moduleName: 'waffle-cake',
+          curentYear: '1000'
+        })
+        .on('end', done);
+    });
+
+    it('creates files', function () {
+      assert.file([
+        'packages/waffle-cake/README.md',
+        'packages/terra-site/src/examples/waffle-cake/Index.jsx'
+      ]);
+    });
+
+    it('creates the mixins and variables files', function () {
+      assert.file([
+        'packages/waffle-cake/src/_mixins.scss',
+        'packages/waffle-cake/src/_variables.scss'
+      ]);
+    });
+
+    it('creates the License and Notice files', function () {
+      assert.file([
+        'packages/waffle-cake/LICENSE',
+        'packages/waffle-cake/NOTICE'
+      ]);
+    });
+
+    it('fills the sass file with some dummy sass', function () {
+      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '@import \'./variables\';');
+      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '@import \'./mixins\';');
+      assert.fileContent('packages/waffle-cake/src/WaffleCake.scss', '.terra-WaffleCake {');
+    });
+
+    it('fills the docs/README file with title cased project data', function () {
+      assert.fileContent('packages/waffle-cake/docs/README.md', 'Terra Waffle Cake');
+    });
+
+    it('fills the package.json file with project data', function () {
+      assert.fileContent('packages/waffle-cake/package.json', 'git+https://github.com/cerner/terra-core.git');
+      assert.fileContent('packages/waffle-cake/package.json', 'https://github.com/cerner/terra-core/issues');
+    });
+
+    it('fills the README file with project data', function () {
+      assert.fileContent('packages/waffle-cake/README.md', '# Terra Waffle Cake');
+      assert.fileContent('packages/waffle-cake/README.md', 'img.shields.io/npm/v/terra-waffle-cake.svg');
+      assert.fileContent('packages/waffle-cake/README.md', 'travis-ci.org/cerner/terra-core.svg');
+      assert.fileContent('packages/waffle-cake/README.md', 'npm install terra-waffle-cake');
+      assert.fileContent('packages/waffle-cake/README.md', '[Documentation](https://github.com/cerner/terra-core/tree/master/packages/terra-waffle-cake/docs)');
+    });
+
+    it('fills the examples Index file with project data', function () {
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import React from 'react';`);
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import WaffleCakeSrc from '!raw-loader!terra-waffle-cake/src/WaffleCake';`);
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import ReadMe from 'terra-waffle-cake/docs/README.md';`);
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `import { version } from 'terra-waffle-cake/package.json';`);
+      assert.fileContent('packages/terra-site/src/examples/waffle-cake/Index.jsx', `export default WaffleCakeExamples;`);
+    });
   });
 
-  it('creates the mixins and variables files', function () {
-    assert.file([
-      'packages/waffle-cake/src/_mixins.scss',
-      'packages/waffle-cake/src/_variables.scss'
-    ]);
-  });
+  describe('terra-clinical module', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../generators/app'))
+        .withPrompts({
+          repository: 'terra-clinical',
+          moduleName: 'monster-cookies',
+          curentYear: '1000'
+        })
+        .on('end', done);
+    });
 
-  it('fills the sass file with some dummy sass', function () {
-    assert.fileContent('packages/waffle-cake/src/Cake.scss', '@import \'./variables\';');
-    assert.fileContent('packages/waffle-cake/src/Cake.scss', '@import \'./mixins\';');
-  });
+    it('creates files', function () {
+      assert.file([
+        'packages/monster-cookies/README.md',
+        'packages/terra-clinical-site/src/examples/monster-cookies/Index.jsx'
+      ]);
+    });
 
-  it('fills the docs/README file with title cased project data', function () {
-    assert.fileContent('packages/waffle-cake/docs/README.md', 'Waffle Cake');
-  });
+    it('creates the mixins and variables files', function () {
+      assert.file([
+        'packages/monster-cookies/src/_mixins.scss',
+        'packages/monster-cookies/src/_variables.scss'
+      ]);
+    });
 
-  it('fills the package.json file with project data', function () {
-    assert.fileContent('packages/waffle-cake/package.json', 'git+https://github.com/cerner/terra-core.git');
-    assert.fileContent('packages/waffle-cake/package.json', 'https://github.com/cerner/terra-core/issues');
-  });
+    it('creates the License and Notice files', function () {
+      assert.file([
+        'packages/monster-cookies/LICENSE',
+        'packages/monster-cookies/NOTICE'
+      ]);
+    });
 
-  it('fills the README file with project data', function () {
-    assert.fileContent('packages/waffle-cake/README.md', '# Waffle Cake');
-    assert.fileContent('packages/waffle-cake/README.md', 'img.shields.io/npm/v/waffle-cake.svg');
-    assert.fileContent('packages/waffle-cake/README.md', 'travis-ci.org/cerner/terra-core.svg');
-    assert.fileContent('packages/waffle-cake/README.md', 'npm install waffle-cake');
-    assert.fileContent('packages/waffle-cake/README.md', '[Documentation](https://github.com/cerner/terra-core/tree/master/packages/waffle-cake/docs)');
-  });
+    it('fills the sass file with some dummy sass', function () {
+      assert.fileContent('packages/monster-cookies/src/MonsterCookies.scss', '@import \'./variables\';');
+      assert.fileContent('packages/monster-cookies/src/MonsterCookies.scss', '@import \'./mixins\';');
+      assert.fileContent('packages/monster-cookies/src/MonsterCookies.scss', '.terraClinical-MonsterCookies {');
+    });
 
-  it('fills the examples Index file with project data', function () {
-    assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `import React from 'react';`);
-    assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `import CakeSrc from '!raw-loader!waffle-cake/src/Cake';`);
-    assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `import ReadMe from 'waffle-cake/docs/README.md';`);
-    assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `import { version } from 'waffle-cake/package.json';`);
-    assert.fileContent('packages/terra-site/src/examples/cake/Index.jsx', `export default CakeExamples;`);
+    it('fills the docs/README file with title cased project data', function () {
+      assert.fileContent('packages/monster-cookies/docs/README.md', 'Terra Clinical Monster Cookies');
+    });
+
+    it('fills the package.json file with project data', function () {
+      assert.fileContent('packages/monster-cookies/package.json', 'git+https://github.com/cerner/terra-clinical.git');
+      assert.fileContent('packages/monster-cookies/package.json', 'https://github.com/cerner/terra-clinical/issues');
+      assert.fileContent('packages/monster-cookies/package.json', 'WEBPACK_CONFIG_PATH=../../../../terra-clinical-site/webpack.config');
+    });
+
+    it('fills the README file with project data', function () {
+      assert.fileContent('packages/monster-cookies/README.md', '# Terra Clinical Monster Cookies');
+      assert.fileContent('packages/monster-cookies/README.md', 'img.shields.io/npm/v/terra-clinical-monster-cookies.svg');
+      assert.fileContent('packages/monster-cookies/README.md', 'travis-ci.org/cerner/terra-clinical.svg');
+      assert.fileContent('packages/monster-cookies/README.md', 'npm install terra-clinical-monster-cookies');
+      assert.fileContent('packages/monster-cookies/README.md', '[Documentation](https://github.com/cerner/terra-clinical/tree/master/packages/terra-clinical-monster-cookies/docs)');
+    });
+
+    it('fills the examples Index file with project data', function () {
+      assert.fileContent('packages/terra-clinical-site/src/examples/monster-cookies/Index.jsx', `import React from 'react';`);
+      assert.fileContent('packages/terra-clinical-site/src/examples/monster-cookies/Index.jsx', `import MonsterCookiesSrc from '!raw-loader!terra-clinical-monster-cookies/src/MonsterCookies';`);
+      assert.fileContent('packages/terra-clinical-site/src/examples/monster-cookies/Index.jsx', `import ReadMe from 'terra-clinical-monster-cookies/docs/README.md';`);
+      assert.fileContent('packages/terra-clinical-site/src/examples/monster-cookies/Index.jsx', `import { version } from 'terra-clinical-monster-cookies/package.json';`);
+      assert.fileContent('packages/terra-clinical-site/src/examples/monster-cookies/Index.jsx', `export default MonsterCookiesExamples;`);
+    });
   });
 });


### PR DESCRIPTION
### Summary
Terra development has moved into two workspaces: terra-core and terra-clinical. Due to namespace formatting and package configurations, the generator needed updated to handle which repository the user was working in to generate appropriate package scaffolding. Issue #35 

### Updates
Upon running `yo terra-module`, the user is prompted with two messages:
1. `Terra repository:` which accepts `terra-core` or `terra-clinical`. It defaults to `terra-core` if no input is provided.
2. `Your module name:`, which is the desired name of the react component being created. Before the user would put `terra-detail-view`, now the user only needs to put `detail-view`. The first prompt handles the name space prefixes. 


@cerner/terra
