### PR TITLE
Added instruction to add new module to command.publish.ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ Input `terra-core` or `terra-clinical`. It defaults to `terra-core` if no input 
 2. `Your module name:`
 Input the desired name of the react component being created. **Note**: the first prompt handles the name space prefixes.
 
-Your new project will be generated in the packages directory of the chosen repository. After generating the project, add a link to your project's examples in site/App.jsx, routes for your project in site/Index.jsx, and links to your tests in site/TestLinks.jsx.
+Your new project will be generated in the packages directory of the chosen repository.
+
+After generating the project, add a link to your project's examples in site/App.jsx, routes for your project in site/Index.jsx, and links to your tests in site/TestLinks.jsx.
+
+Finally, add your package name to the command.publish.ignore in the lerna.json file. This prevents npm package publishing until your module is complete.  
+
 
 Now you are ready to start building your terra module!
 


### PR DESCRIPTION
### Summary
Npm package publishing is now done with lerna publishing command. Because of this, new packages need to be added to the command.publish.ignore array in the lerna.json file until the package is ready for publishing. This PR updates the README to instruct users to add their newly generated module to this array.

@cerner/terra
