### PR TITLE
Add release scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   },
   "repository": "/generator-terra-module",
   "scripts": {
-    "prepublish": "gulp prepublish",
+    "release:major": "npm test && gulp prepublish && npm version major -m \"Released version %s\" && npm publish && git push --follow-tags",
+    "release:minor": "npm test && gulp prepublish && npm version minor -m \"Released version %s\" && npm publish && git push --follow-tags",
+    "release:patch": "npm test && gulp prepublish && npm version patch -m \"Released version %s\" && npm publish && git push --follow-tags",
     "test": "gulp"
   },
   "private": true


### PR DESCRIPTION
### Summary
The current package.json file has a prepublish script. This runs `gulp prepublish`. We've run into issues with the npm `prepublish` script being run on `npm install` before. This code change removes the the npm `prepublish` and adds release scripts that will run tests via `npm test` as well as running `gulp prepublish` before releasing.

Thanks for contributing to Terra. 
@cerner/terra