### PR TITLE
Add .npmrc Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 * Update package templates for Jest v21.0.2 in terra repos
 * Update nightwatch test templates
 * Update test scripts in package templates
+* Add .npmrc template
 
 1.1.0 - (Aug 8, 2017)
 ------------------

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -222,6 +222,11 @@ module.exports = yeoman.Base.extend({
       this.destinationPath(this.props.baseDirectory + '.npmignore')
     );
 
+    this.fs.copyTpl(
+      this.templatePath('_.npmrc'),
+      this.destinationPath(this.props.baseDirectory + '.npmrc')
+    );
+
     this.fs.write(this.destinationPath(this.props.baseDirectory + 'src/_mixins.scss'), '');
     this.fs.write(this.destinationPath(this.props.baseDirectory + 'src/_variables.scss'), '');
   },

--- a/generators/app/templates/_.npmrc
+++ b/generators/app/templates/_.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/test/app.js
+++ b/test/app.js
@@ -80,6 +80,7 @@ describe('generator-terra-module:app', function () {
       assert.fileContent('packages/terra-waffle-cake/.npmignore', `target`);
       assert.fileContent('packages/terra-waffle-cake/.npmignore', `tests`);
       assert.fileContent('packages/terra-waffle-cake/.npmignore', `reports`);
+      assert.fileContent('packages/terra-waffle-cake/.npmrc', `package-lock=false`);
     });
   });
 
@@ -163,6 +164,9 @@ describe('generator-terra-module:app', function () {
         assert.fileContent(ignore, `src`);
         assert.fileContent(ignore, `node_modules`);
         assert.fileContent(ignore, `*.log`);
+
+        const npmrc = `packages/${repository}-monster-cookies/.npmrc`;
+        assert.fileContent(npmrc, `package-lock=false`);
       });
     });
   });


### PR DESCRIPTION
### Summary
Adding this package-lock allows expected install behavior we had prior to updating to node v8.