### PR TITLE
Add terra-framework to readme.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@ Cerner Corporation
 - Emily Rohrbough [@emilyrohrbough]
 - Mike Hemesath [@mhemesath]
 - Brett Jankord [@bjankord]
+- Derek Yu [@yuderekyu]
 
 [@gneatgeek]: https://github.com/gneatgeek
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -15,3 +16,4 @@ Cerner Corporation
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@mhemesath]: https://github.com/mhemesath
 [@bjankord]: https://github.com/bjankord
+[@yuderekyu]: https://github.com/yuderekyu

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yo terra-module
 ```
 From here, you will be prompted with two messages:
 1. `Terra repository:`
-Input `terra-core`, `terra-clinical` or `terra-consumer`. It defaults to `terra-core` if no input is provided.
+Input `terra-core`, `terra-clinical`, `terra-consumer`, or `terra-framework`. It defaults to `terra-core` if no input is provided.
 2. `Your module name:`
 Input the desired name of the react component being created. **Note**: the first prompt handles the name space prefixes.
 


### PR DESCRIPTION
### Summary
Add `terra-framework` to the list of repositories packages can be generated in.

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
