### PR TITLE
Fix CSS lint error

### DIFF
--- a/generators/app/templates/src/projectName.scss
+++ b/generators/app/templates/src/projectName.scss
@@ -1,5 +1,5 @@
 :local {
   .<%= cssClassName %> {
-
+    /* TODO: Add styles */
   }
 }


### PR DESCRIPTION
Adds a TODO comment in the empty style block. This fixes a lint error where style blocks can't be empty.

