### PR TITLE
Update package.json

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -23,12 +23,14 @@
   "peerDependencies": {
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "terra-base": "^3.1.0"
+    "terra-base": "^3.1.0",
+    "terra-props-table": "^2.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-base": "^3.1.0"
+    "terra-base": "^3.1.0",
+    "terra-props-table": "^2.0.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",


### PR DESCRIPTION
### Summary
terra-props-table is used in our example files. With this, we need to list it as a dependency so it is installed when we go to build out the examples.

* https://github.com/cerner/terra-framework/blob/master/packages/terra-application-links/examples/Index.site-page.jsx#L3
* https://github.com/cerner/terra-framework/blob/master/packages/terra-application-links/examples/Index.site-page.jsx#L40