### PR TITLE
Auto generate change log entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ------------------
 ### Added
-* Generate CHANGELOG entry in docs
+* Generate CHANGELOG entry in the terra-dev-site docs
+* Added ChangeLog.jsx template for terra-dev-site docs
 
 1.11.0 - (June 26, 2018)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ------------------
+### Added
+* Generate CHANGELOG entry in docs
 
 1.11.0 - (June 26, 2018)
 ------------------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Cerner Corporation
 - Brett Jankord [@bjankord]
 - Derek Yu [@yuderekyu]
 - Ben Boersma [@BenBoersma]
+- Tom Wu [@tomleewu]
 
 [@gneatgeek]: https://github.com/gneatgeek
 [@Matt-Butler]: https://github.com/Matt-Butler
@@ -19,3 +20,4 @@ Cerner Corporation
 [@bjankord]: https://github.com/bjankord
 [@yuderekyu]: https://github.com/yuderekyu
 [@BenBoersma]: https://github.com/BenBoersma
+[@tomleewu]: https://github.com/tomleewu

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -167,9 +167,19 @@ module.exports = yeoman.Base.extend({
     // Add Doc Index
     this.fs.copyTpl(
       this.templatePath('src/terra-dev-site/Index.jsx'),
-      this.destinationPath(this.props.baseDirectory + 'src/terra-dev-site/doc/' + this.props.moduleClassName + '.doc.jsx'),
+      this.destinationPath(this.props.baseDirectory + 'src/terra-dev-site/doc/' + this.props.moduleClassName + '/' + this.props.moduleClassName + '.1.doc.jsx'),
       {
         projectClassName: this.props.moduleClassName,
+        repository: this.props.repository
+      }
+    );
+
+    // Add Doc ChangeLog
+    this.fs.copyTpl(
+      this.templatePath('src/terra-dev-site/ChangeLog.jsx'),
+      this.destinationPath(this.props.baseDirectory + 'src/terra-dev-site/doc/' + this.props.moduleClassName + '/ChangeLog.2.doc.jsx'),
+      {
+        projectClassName: this.props.moduleName,
         repository: this.props.repository
       }
     );

--- a/generators/app/templates/src/terra-dev-site/ChangeLog.jsx
+++ b/generators/app/templates/src/terra-dev-site/ChangeLog.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions */
 import React from 'react';
 import DocTemplate from 'terra-doc-template';
 import ChangeLog from '../../../../CHANGELOG.md';

--- a/generators/app/templates/src/terra-dev-site/ChangeLog.jsx
+++ b/generators/app/templates/src/terra-dev-site/ChangeLog.jsx
@@ -1,0 +1,14 @@
+/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions */
+import React from 'react';
+import DocTemplate from 'terra-doc-template';
+import ChangeLog from '../../../../CHANGELOG.md';
+
+const DocPage = () => (
+  <DocTemplate
+    packageName="<%= projectClassName %>"
+    srcPath="https://github.com/cerner/<%= repository %>/tree/master/packages/<%= projectClassName %>"
+    readme={ChangeLog}
+  />
+);
+
+export default DocPage;

--- a/generators/app/templates/src/terra-dev-site/Index.jsx
+++ b/generators/app/templates/src/terra-dev-site/Index.jsx
@@ -1,15 +1,15 @@
 /* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-duplicates */
 import React from 'react';
 import DocTemplate from 'terra-doc-template';
-import ReadMe from '../../../docs/README.md';
-import { version } from '../../../package.json';
+import ReadMe from '../../../../docs/README.md';
+import { version } from '../../../../package.json';
 
 // Component Source
-import <%= projectClassName %>Src from '!raw-loader!../../../src/<%= projectClassName %>';
+import <%= projectClassName %>Src from '!raw-loader!../../../../src/<%= projectClassName %>';
 
 // Example Files
-import Default<%= projectClassName %> from './example/Default<%= projectClassName %>';
-import Default<%= projectClassName %>Src from '!raw-loader!../../../src/terra-dev-site/doc/example/Default<%= projectClassName %>.jsx';
+import Default<%= projectClassName %> from '../example/Default<%= projectClassName %>';
+import Default<%= projectClassName %>Src from '!raw-loader!../../../../src/terra-dev-site/doc/example/Default<%= projectClassName %>.jsx';
 
 const DocPage = () => (
   <DocTemplate

--- a/test/app.js
+++ b/test/app.js
@@ -29,7 +29,8 @@ describe('generator-terra-module:app', function () {
         assert.file([
           `packages/${repository}-monster-cookies/README.md`,
           `packages/${repository}-monster-cookies/CHANGELOG.md`,
-          `packages/${repository}-monster-cookies/src/terra-dev-site/doc/MonsterCookies.doc.jsx`,
+          `packages/${repository}-monster-cookies/src/terra-dev-site/doc/MonsterCookies/MonsterCookies.1.doc.jsx`,
+          `packages/${repository}-monster-cookies/src/terra-dev-site/doc/MonsterCookies/ChangeLog.2.doc.jsx`,
           `packages/${repository}-monster-cookies/src/terra-dev-site/test/${repoNamespace}monster-cookies/DefaultMonsterCookies.test.jsx`
         ]);
       });
@@ -84,12 +85,12 @@ describe('generator-terra-module:app', function () {
       });
 
       it('fills the site examples Index file with project data', function () {
-        const index = `packages/${repository}-monster-cookies/src/terra-dev-site/doc/MonsterCookies.doc.jsx`;
+        const index = `packages/${repository}-monster-cookies/src/terra-dev-site/doc/MonsterCookies/MonsterCookies.1.doc.jsx`;
 
         assert.fileContent(index, `import React from 'react';`);
-        assert.fileContent(index, `import DefaultMonsterCookiesSrc from '!raw-loader!../../../src/terra-dev-site/doc/example/DefaultMonsterCookies.jsx';`);
-        assert.fileContent(index, `import ReadMe from '../../../docs/README.md';`);
-        assert.fileContent(index, `import { version } from '../../../package.json';`);
+        assert.fileContent(index, `import DefaultMonsterCookiesSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/DefaultMonsterCookies.jsx';`);
+        assert.fileContent(index, `import ReadMe from '../../../../docs/README.md';`);
+        assert.fileContent(index, `import { version } from '../../../../package.json';`);
         assert.fileContent(index, `export default DocPage;`);
       });
 

--- a/test/app.js
+++ b/test/app.js
@@ -20,7 +20,7 @@ describe('generator-terra-module:app', function () {
           .withPrompts({
             repository: repositoryName,
             moduleName: 'monster-cookies',
-            curentYear: '1000'
+            currentYear: '1000'
           })
           .on('end', done);
       });
@@ -92,6 +92,15 @@ describe('generator-terra-module:app', function () {
         assert.fileContent(index, `import ReadMe from '../../../../docs/README.md';`);
         assert.fileContent(index, `import { version } from '../../../../package.json';`);
         assert.fileContent(index, `export default DocPage;`);
+      });
+
+      it('fills the ChangeLog with appropriate Git URL', function () {
+        const changelog = `packages/${repository}-monster-cookies/src/terra-dev-site/doc/MonsterCookies/ChangeLog.2.doc.jsx`;
+
+        assert.fileContent(changelog, `import React from 'react';`);
+        assert.fileContent(changelog, `import DocTemplate from 'terra-doc-template';`);
+        assert.fileContent(changelog, `import ChangeLog from '../../../../CHANGELOG.md';`);
+        assert.fileContent(changelog, `srcPath="https://github.com/cerner/${repositoryName}/tree/master/packages/monster-cookies"`);
       });
 
       it('fills the examples Index file with project data', function () {


### PR DESCRIPTION
### Summary
Added feature to generate the Change Log onto the terra-dev-site entry of new components.

Closes #99.