### PR TITLE
Fix lint issues that show up on fresh generation

### DIFF
--- a/generators/app/templates/src/projectName.jsx
+++ b/generators/app/templates/src/projectName.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import 'terra-base/lib/baseStyles';
-import styles from './<%= scssFileName %>.scss';
+import styles from './<%= scssFileName %>.module.scss';
 
 const cx = classNames.bind(styles);
 
 const propTypes = {
- /*
- * Content to be displayed as the name
- */
+  /**
+   * Content to be displayed as the name
+   */
   name: PropTypes.string,
 };
 

--- a/generators/app/templates/src/terra-dev-site/Index.jsx
+++ b/generators/app/templates/src/terra-dev-site/Index.jsx
@@ -1,8 +1,8 @@
-/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-duplicates */
+/* eslint-disable import/no-webpack-loader-syntax, import/first, import/extensions, import/no-duplicates, import/no-unresolved */
 import React from 'react';
 import DocTemplate from 'terra-doc-template';
 import ReadMe from '../../../../docs/README.md';
-import { version } from '../../../../package.json';
+import { name } from '../../../../package.json';
 
 // Component Source
 import <%= projectClassName %>Src from '!raw-loader!../../../../src/<%= projectClassName %>';

--- a/generators/app/templates/tests/moduleName-spec.js
+++ b/generators/app/templates/tests/moduleName-spec.js
@@ -1,4 +1,4 @@
-/* global browser, Terra */
+/* global browser, Terra, before */
 const viewports = Terra.viewports('tiny', 'medium', 'large');
 
 describe('<%= moduleClassName %>', () => {

--- a/test/app.js
+++ b/test/app.js
@@ -90,7 +90,7 @@ describe('generator-terra-module:app', function () {
         assert.fileContent(index, `import React from 'react';`);
         assert.fileContent(index, `import DefaultMonsterCookiesSrc from '!raw-loader!../../../../src/terra-dev-site/doc/example/DefaultMonsterCookies.jsx';`);
         assert.fileContent(index, `import ReadMe from '../../../../docs/README.md';`);
-        assert.fileContent(index, `import { version } from '../../../../package.json';`);
+        assert.fileContent(index, `import { name } from '../../../../package.json';`);
         assert.fileContent(index, `export default DocPage;`);
       });
 


### PR DESCRIPTION
### Summary
Running yo-terra to generate a new package results in some code that contains lint. These changes resolve the lint issues.