### PR TITLE
Removed terra-base as a peer dependency

### DIFF
--- a/generators/app/templates/CHANGELOG.md
+++ b/generators/app/templates/CHANGELOG.md
@@ -1,5 +1,7 @@
 ChangeLog
 =========
+### Changed
+* Removed terra-base has a peer dependency.
 
 Unreleased
 -----------------

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -22,8 +22,7 @@
   "homepage": "https://github.com/cerner/<%=repository%>#readme",
   "peerDependencies": {
     "react": "^16.4.2",
-    "react-dom": "^16.4.2",
-    "terra-base": "^3.1.0"
+    "react-dom": "^16.4.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/generators/app/templates/src/projectName.jsx
+++ b/generators/app/templates/src/projectName.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import 'terra-base/lib/baseStyles';
 import styles from './<%= scssFileName %>.module.scss';
 
 const cx = classNames.bind(styles);


### PR DESCRIPTION
### Summary
Removed terra-base as a peer dependency of components.

Resolves [#118](https://github.com/cerner/generator-terra-module/issues/118)