### PR TITLE
Updated mocha version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 
 ### Changed
 * Updated generated test template to utilize `Terra.should.validateElement()` from terra-toolkit.
+* Updated mocha dependency to 6.1.4 (current version)
 
 1.16.0 - (March 28, 2019)
 ------------------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,7 +11,7 @@ Cerner Corporation
 - Ben Boersma [@BenBoersma]
 - Tom Wu [@tomleewu]
 - Lalitha Kalidindi [@lalitha94]
-- Alex Brisimitzakis [@alexbrizi]
+- Alex Brisimitzakis [@AlexB98]
 - Naveen Kumar Ramamurthy [@nramamurth]
 
 [@gneatgeek]: https://github.com/gneatgeek
@@ -25,5 +25,5 @@ Cerner Corporation
 [@BenBoersma]: https://github.com/BenBoersma
 [@tomleewu]: https://github.com/tomleewu
 [@lalitha94]:https://github.com/lalitha94
-[@alexbrizi]:https://github.com/AlexBrizi
+[@alexbrizi]:https://github.com/AlexB98
 [@nramamurth]: https://github.com/nramamurth

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "eslint": "^5.0.0",
     "eslint-config-terra": "^2.0.0",
-    "mocha": "^5.2.0",
+    "mocha": "^6.1.4",
     "yeoman-assert": "^3.0.0",
     "yeoman-test": "^2.0.0"
   },


### PR DESCRIPTION
### Summary
Updated [mocha](https://www.npmjs.com/package/mocha) to its current version (6.1.4).

Resolves [#125](https://github.com/cerner/generator-terra-module/issues/125)

